### PR TITLE
Use raw GitHub link for queries.json reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ lets you easily switch between teams.
 To connect to the cloud from the Brim app, click on the lake dropdown
 in the upper left area of the window where you see the down carrot
 and click on _Add Lake..._.  Once the cloud connection has been created,
-you can use this dropdown to switch between your local lake the cloud
+you can use this dropdown to switch between your local lake and the cloud
 (as well as other cloud lakes or lakes that you set up on your own server
 with `zed serve`).
 
-Under the _Name_ input, provide a name for the lake connection that you would like
+Under the _Name_ input, provide a name for the lake connection that you would like to
 appear in listing of available lakes.  Under the Host input, provide the URL
 of the lake service, in this case, `https://<custom>.lake.brimdata.io`
 
@@ -92,7 +92,7 @@ Authenticate your lake connection using `zed auth login`:
 zed auth login
 ```
 This will launch your browser with an authentication dialogue pointing
-at the auth0 service for Brim and command will print an confirmation code
+at the auth0 service for Brim and command will print a confirmation code
 on the terminal.  Once you confirm in the auth0 web dialogue, `zed auth login`
 will report success and you will be logged in.
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ of the lake service, in this case, `https://<custom>.lake.brimdata.io`
 
 You can import some sample queries relevant to the Welcome pools
 into the app's query library by
-downloading [queries.json](./queries.json).
+downloading [queries.json](./queries.json?raw=1).
 You can simply drag this file onto the **Queries** panel in the Brim app
 and this will add a query folder called "Welcome".
 You may also import this file by clicking on the `+` button


### PR DESCRIPTION
When I was running through the cloud README steps, upon seeing the suggestion to download the `queries.json` file, I right-clicked in my browser and selected "Save Link As..." Since the link was to a "regular" GitHub location, what I got was an unusable HTML and not an actual  SON file that could be dragged successfully into the Brim app. GitHub-savvy users would be familiar with this phenomenon and would hopefully notice it by hovering over the link or might left-click the link first and recognize the need to then click the "Raw" button. However, since you may not be able to count on 100% user intimate familiarity with GitHub, I'd recommend flipping around to linking to the raw representation as done in this PR.

While I was in there, I also fixed a couple minor typos.